### PR TITLE
install expect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG https_proxy=${https_proxy}
 ENV http_proxy=${http_proxy}
 ENV https_proxy=${https_proxy}
 
-RUN apt-get update && apt-get install -y python-setuptools python-dev
+RUN apt-get update && apt-get install -y python-setuptools python-dev expect
 RUN easy_install pip
 RUN pip install ansible
 RUN npm install ansibrest -g


### PR DESCRIPTION
hi there,

I'm trying to use docker `muddydixon/ansibrest` image in my project, but I have a playbook which uses local_action + `expect` command to workaround password input. Please accept this pull request!

I tested building the image with this command:

```
docker build \
  -t tily/ansibrest
  --build-arg http_proxy=http://myproxy:8080 \
  --build-arg https_proxy=http://myproxy:8080 \
  .
```

Thanks in advance.